### PR TITLE
feat(roster): local year-long rotating roster (FT/PT), admin UI, CSV/JSON export

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
+    "luxon": "^3.4.4",
     "zod": "^3.22.2",
     "zustand": "^4.3.6"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import Login from './pages/Login.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 import Roster from './pages/Roster.jsx';
 import Timesheet from './pages/Timesheet.jsx';
 import Swaps from './pages/Swaps.jsx';
+import RosterAdmin from './pages/RosterAdmin.jsx';
 import { useAuth } from './lib/auth.jsx';
 import Toast from './components/Toast.jsx';
 
@@ -16,9 +17,14 @@ import Toast from './components/Toast.jsx';
  */
 function App() {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return <div className="container">Loading…</div>;
+  }
+
+  if (!user && location.pathname === '/admin/roster') {
+    return <RosterAdmin />;
   }
 
   // If no user is signed in, always show the login page.  Once the
@@ -34,6 +40,7 @@ function App() {
         <Route path="/roster" element={<Roster />} />
         <Route path="/timesheet" element={<Timesheet />} />
         <Route path="/swaps" element={<Swaps />} />
+        <Route path="/admin/roster" element={<RosterAdmin />} />
         {/* Unknown routes redirect to the dashboard */}
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>

--- a/frontend/src/pages/RosterAdmin.jsx
+++ b/frontend/src/pages/RosterAdmin.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { generateYear, toCSV, storeRoster, loadRoster } from '../utils/generate-year';
+
+export default function RosterAdmin() {
+  const [year, setYear] = useState(2025);
+  const [anchor, setAnchor] = useState('2025-09-08'); // Monday
+  const [data, setData] = useState(null);
+  const [msg, setMsg] = useState('');
+
+  const onGenerate = () => {
+    const d = generateYear({ year: Number(year), anchorMondayISO: anchor });
+    setData(d);
+    setMsg(`Generated FT:${d.fullTime.length} PT:${d.partTime.length}`);
+  };
+
+  const onSave = () => {
+    if (!data) return;
+    storeRoster(data);
+    setMsg('Saved locally');
+  };
+
+  const dl = (text, name) => {
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([text], { type: 'text/plain' }));
+    a.download = name;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  };
+
+  const onExportFT = () => data && dl(toCSV(data.fullTime), `fulltime-${data.year}.csv`);
+  const onExportPT = () => data && dl(toCSV(data.partTime), `parttime-${data.year}.csv`);
+  const onExportJSON = () => data && dl(JSON.stringify(data, null, 2), `roster-${data.year}.json`);
+  const onLoad = () => setData(loadRoster(Number(year)));
+
+  return (
+    <div style={{maxWidth: 720, margin: '2rem auto'}}>
+      <h2>Roster Admin (Local)</h2>
+      <label>
+        Year:&nbsp;
+        <input type="number" value={year} onChange={e => setYear(e.target.value)} />
+      </label>
+      &nbsp;&nbsp;
+      <label>
+        Anchor Monday:&nbsp;
+        <input type="date" value={anchor} onChange={e => setAnchor(e.target.value)} />
+      </label>
+
+      <div style={{marginTop: 12}}>
+        <button onClick={onGenerate}>Generate</button>
+        <button onClick={onSave} disabled={!data}>Save (local)</button>
+        <button onClick={onExportFT} disabled={!data}>Export CSV (FT)</button>
+        <button onClick={onExportPT} disabled={!data}>Export CSV (PT)</button>
+        <button onClick={onExportJSON} disabled={!data}>Download JSON</button>
+        <button onClick={onLoad}>Load saved</button>
+      </div>
+
+      <p style={{color:'#0a7'}}>{msg}</p>
+
+      {data && (
+        <>
+          <h3>Preview (first 14 rows FT / PT)</h3>
+          <pre style={{background:'#111', color:'#ddd', padding:8, borderRadius:6, overflow:'auto'}}>
+{JSON.stringify({FT: data.fullTime.slice(0,14), PT: data.partTime.slice(0,14)}, null, 2)}
+          </pre>
+        </>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/utils/generate-year.js
+++ b/frontend/src/utils/generate-year.js
@@ -1,0 +1,59 @@
+import { DateTime } from 'luxon';
+import { TIMEZONE, FULL_TIME_WEEK, PART_TIME_WEEK } from './roster-rotation';
+
+const DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+
+function weekDates(weekStartISO) {
+  const start = DateTime.fromISO(weekStartISO, { zone: TIMEZONE });
+  return DAYS.map((_, i) => start.plus({ days: i }));
+}
+
+function expandWeek(map, dates) {
+  const out = [];
+  DAYS.forEach((d, i) => {
+    (map[d] || []).forEach(shift => {
+      out.push({
+        date: dates[i].toISODate(),
+        day: d,
+        start: shift.start,
+        end: shift.end
+      });
+    });
+  });
+  return out;
+}
+
+export function generateYear({ year, anchorMondayISO }) {
+  const end = DateTime.fromObject({ year, month: 12, day: 31 }, { zone: TIMEZONE });
+  let weekStart = DateTime.fromISO(anchorMondayISO, { zone: TIMEZONE });
+
+  const fullTime = [];
+  const partTime = [];
+  for (; weekStart <= end; weekStart = weekStart.plus({ weeks: 1 })) {
+    const dates = weekDates(weekStart.toISODate());
+    fullTime.push(...expandWeek(FULL_TIME_WEEK, dates));
+    partTime.push(...expandWeek(PART_TIME_WEEK, dates));
+  }
+  return { year, timezone: TIMEZONE, anchorMondayISO, fullTime, partTime };
+}
+
+export function toCSV(rows) {
+  const header = 'Date,Day,Shift Start,Shift End';
+  const body = rows.map(r => `${r.date},${r.day},${r.start},${r.end}`).join('\n');
+  return `${header}\n${body}\n`;
+}
+
+// local persistence helpers
+export const storeRoster = (data) => {
+  localStorage.setItem(`roster.fullTime.${data.year}`, JSON.stringify(data.fullTime));
+  localStorage.setItem(`roster.partTime.${data.year}`, JSON.stringify(data.partTime));
+  localStorage.setItem('roster.meta', JSON.stringify({ tz: data.timezone, anchor: data.anchorMondayISO }));
+};
+
+export const loadRoster = (year) => {
+  const full = JSON.parse(localStorage.getItem(`roster.fullTime.${year}`) || '[]');
+  const part = JSON.parse(localStorage.getItem(`roster.partTime.${year}`) || '[]');
+  const meta = JSON.parse(localStorage.getItem('roster.meta') || '{}');
+  return { year, fullTime: full, partTime: part, meta };
+};
+

--- a/frontend/src/utils/roster-rotation.js
+++ b/frontend/src/utils/roster-rotation.js
@@ -1,0 +1,34 @@
+export const TIMEZONE = 'Australia/Sydney';
+
+export const SHIFT = {
+  E0500_1500: { start: '05:00', end: '15:00' },
+  E0600_1400: { start: '06:00', end: '14:00' },
+  D0730_1930: { start: '07:30', end: '19:30' },
+  D1230_2030: { start: '12:30', end: '20:30' },
+  A1330_2130: { start: '13:30', end: '21:30' },
+  PT0500_1300: { start: '05:00', end: '13:00' },
+  PT0800_1600: { start: '08:00', end: '16:00' },
+  PT1700_2230: { start: '17:00', end: '22:30' },
+};
+
+// EDIT these to your true weekly patterns (Mon..Sun)
+export const FULL_TIME_WEEK = {
+  Mon: [SHIFT.E0500_1500, SHIFT.D0730_1930],
+  Tue: [SHIFT.E0500_1500],
+  Wed: [SHIFT.D0730_1930],
+  Thu: [SHIFT.D1230_2030, SHIFT.A1330_2130],
+  Fri: [SHIFT.E0600_1400],
+  Sat: [],
+  Sun: []
+};
+
+export const PART_TIME_WEEK = {
+  Mon: [SHIFT.PT1700_2230],
+  Tue: [],
+  Wed: [SHIFT.PT1700_2230],
+  Thu: [SHIFT.PT1700_2230],
+  Fri: [SHIFT.PT1700_2230],
+  Sat: [SHIFT.PT0800_1600],
+  Sun: []
+};
+


### PR DESCRIPTION
## Summary
- add shift definitions and weekly templates for full-time and part-time rosters
- generate year-long rosters with Luxon using Australia/Sydney timezone and localStorage helpers
- admin UI for generating, saving, and exporting rosters; route accessible without auth

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b55e8bc708832ba26b8af4ecf6a937