### PR TITLE
fix(wallet-image): replace encoder/decoder JS with validated, user-friendly versions

### DIFF
--- a/frontend/public/main.js
+++ b/frontend/public/main.js
@@ -1,0 +1,107 @@
+// main.js  (ESM)
+// Drop-in hardened encoder logic for image-based wallet creation.
+
+import initEncoder, {
+  generate_wallet,
+  embed_key_in_image_with_password
+} from './pkg/condor_encoder.js';
+
+// ==== Adjust selectors here if your HTML uses different IDs ====
+const SEL = {
+  genBtn: '#generate-btn',
+  pass1: '#pass-1',
+  pass2: '#pass-2',
+  file:  '#png-input',         // <input type="file" accept="image/png">
+  embed: '#embed-btn',
+  addr:  '#address-out',
+  status:'#status'
+};
+// ===============================================================
+
+let wallet = null;     // { address, key } – kept in memory only
+let lastBlobUrl = null;
+
+function $(q) { const el = document.querySelector(q); if (!el) throw new Error(`Missing element ${q}`); return el; }
+function setText(q, text) { $(q).textContent = text; }
+function ok(msg)   { setText(SEL.status, `✅ ${msg}`); }
+function bad(msg)  { setText(SEL.status, `❌ ${msg}`); }
+function info(msg) { setText(SEL.status, `ℹ️ ${msg}`); }
+
+function normalizePk(pk) {
+  let p = String(pk || '').trim();
+  if (!p.startsWith('0x')) p = '0x' + p;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(p)) throw new Error('Invalid private key format (need 0x + 64 hex chars)');
+  return p;
+}
+
+async function fileToBytes(file) {
+  const buf = await file.arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+function downloadBlob(bytes, name) {
+  const blob = new Blob([bytes], { type: 'image/png' });
+  if (lastBlobUrl) URL.revokeObjectURL(lastBlobUrl);
+  lastBlobUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = lastBlobUrl;
+  a.download = name;
+  a.click();
+}
+
+async function onGenerate() {
+  try {
+    info('Initialising encoder…');
+    await initEncoder();
+    info('Generating wallet…');
+    const w = generate_wallet();                // { address, key } from WASM
+    w.key = normalizePk(w.key);
+    wallet = w;
+    setText(SEL.addr, w.address);
+    ok('Wallet generated. Choose a PNG and set a passphrase to embed.');
+  } catch (e) {
+    console.error(e);
+    bad(e?.message || String(e));
+  }
+}
+
+async function onEmbed() {
+  try {
+    if (!wallet?.key) throw new Error('Generate a wallet first.');
+    const p1 = $(SEL.pass1).value;
+    const p2 = $(SEL.pass2).value;
+    if (p1.length < 8) throw new Error('Passphrase must be at least 8 characters.');
+    if (p1 !== p2)     throw new Error('Passphrases do not match.');
+    const file = $(SEL.file).files?.[0];
+    if (!file) throw new Error('Select a PNG image to embed the wallet.');
+    if (!/\.png$/i.test(file.name)) throw new Error('Only PNG files are supported.');
+
+    info('Reading PNG…');
+    const bytes = await fileToBytes(file);
+
+    info('Embedding wallet into image…');
+    const outBytes = embed_key_in_image_with_password(bytes, wallet.key, p1);
+
+    const outName = `wallet_${wallet.address.slice(0,6)}.png`;
+    downloadBlob(outBytes, outName);
+
+    ok('Wallet embedded. Image downloaded. Keep it safe!');
+    // scrub inputs AFTER download to avoid empty embeds
+    $(SEL.pass1).value = '';
+    $(SEL.pass2).value = '';
+    $(SEL.file).value = '';
+    // Optionally clear wallet from memory when you navigate away.
+  } catch (e) {
+    console.error(e);
+    bad(e?.message || String(e));
+  }
+}
+
+// ---- Hook up UI ----
+window.addEventListener('DOMContentLoaded', () => {
+  $(SEL.genBtn).addEventListener('click', onGenerate);
+  $(SEL.embed).addEventListener('click', onEmbed);
+  setText(SEL.addr, '');
+  info('Ready.');
+});
+

--- a/frontend/public/unlock.js
+++ b/frontend/public/unlock.js
@@ -1,0 +1,79 @@
+// unlock.js  (ESM)
+// Drop-in hardened decoder logic for image-based wallet login.
+
+import initDecoder, {
+  decode_wallet_from_image
+} from './pkg/condor_wallet.js';
+
+// ==== Adjust selectors here if your HTML uses different IDs ====
+const SEL = {
+  file:   '#unlock-file',      // <input type="file" accept="image/png">
+  pass:   '#unlock-pass',
+  btn:    '#unlock-btn',
+  addr:   '#unlock-address',
+  status: '#unlock-status'
+};
+// ===============================================================
+
+function $(q) { const el = document.querySelector(q); if (!el) throw new Error(`Missing element ${q}`); return el; }
+function setText(q, text) { $(q).textContent = text; }
+function ok(msg)   { setText(SEL.status, `✅ ${msg}`); }
+function bad(msg)  { setText(SEL.status, `❌ ${msg}`); }
+function info(msg) { setText(SEL.status, `ℹ️ ${msg}`); }
+
+function normalizePk(pk) {
+  let p = String(pk || '').trim();
+  if (!p.startsWith('0x')) p = '0x' + p;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(p)) throw new Error('Invalid private key format (need 0x + 64 hex chars)');
+  return p;
+}
+
+async function fileToBytes(file) {
+  const buf = await file.arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+async function onUnlock() {
+  try {
+    info('Initialising decoder…');
+    await initDecoder();
+
+    const file = $(SEL.file).files?.[0];
+    if (!file) throw new Error('Select the wallet PNG image.');
+    if (!/\.png$/i.test(file.name)) throw new Error('Only PNG files are supported.');
+
+    const pass = $(SEL.pass).value;
+    if (!pass) throw new Error('Enter your passphrase.');
+
+    info('Reading PNG…');
+    const bytes = await fileToBytes(file);
+
+    info('Decoding wallet from image…');
+    const res = decode_wallet_from_image(bytes, pass); // { address, key } on success
+    if (!res || !res.key) throw new Error('No wallet found in this image (wrong file or corrupted).');
+
+    const pk = normalizePk(res.key);
+    setText(SEL.addr, res.address);
+    ok('Wallet decoded. You can now sign in with this address.');
+
+    // SECURITY: hold pk in memory only; hand it to your app's auth flow here:
+    // window.myAppSignIn({ address: res.address, privateKey: pk })
+
+  } catch (e) {
+    console.error(e);
+    const msg = String(e?.message || e);
+    if (/passphrase/i.test(msg) || /authentication/i.test(msg)) {
+      bad('Incorrect passphrase. Please try again.');
+    } else {
+      bad(msg);
+    }
+  }
+}
+
+// ---- Hook up UI ----
+window.addEventListener('DOMContentLoaded', () => {
+  $(SEL.btn).addEventListener('click', onUnlock);
+  setText(SEL.addr, '');
+  info('Ready.');
+});
+


### PR DESCRIPTION
## Summary
- Hardened PNG wallet generation logic with input validation and clear status messages
- Added robust wallet image decoder with user-friendly errors

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b670fd5328832baf6b4706bed288b8