### PR TITLE
fix(pwa): guard virtual:pwa-register import so dev doesn’t break when plugin is disabled

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,9 +5,12 @@ import App from './App.jsx';
 import './index.css';
 import { AuthProvider } from './lib/auth.jsx';
 import Web3Providers from './web3/provider.jsx';
-import { registerSW } from 'virtual:pwa-register';
 
-registerSW({ immediate: true });
+if (import.meta.env.PROD || import.meta.env.VITE_ENABLE_PWA_DEV === 'true') {
+  import('virtual:pwa-register')
+    .then(({ registerSW }) => registerSW({ immediate: true }))
+    .catch(() => {});
+}
 
 // Entry point for the React app.  We wrap the App component in a
 // BrowserRouter so that react‑router can manage client side routes.


### PR DESCRIPTION
## Summary
- guard service worker registration so `virtual:pwa-register` is only loaded in production or when explicitly enabled

## Testing
- `yarn dev` *(fails: vite-plugin-pwa missing)*
- `VITE_ENABLE_PWA_DEV=true yarn dev` *(fails: vite-plugin-pwa missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b750c91024832bb70d48cc6d2885db